### PR TITLE
build static binaries

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -17,7 +17,8 @@ stages:
   - stage: Build
     displayName: 'Run Build Script on all Platforms'
     jobs:
-      - job: Build
+      - job: language_bindings
+        timeoutInMinutes: 180
         variables:
           CVC4Version: '1.8'
           UbuntuMirror: 'http://azure.archive.ubuntu.com/ubuntu'
@@ -35,6 +36,30 @@ stages:
           - task: Bash@3
             inputs:
               filePath: 'build.sh'
+            env:
+              BUILD_NAME: $(VMImage)
+              CVC4_VERSION: $(CVC4Version)
+              UBUNTU_MIRROR: $(UbuntuMirror)
+              UBUNTU_SWIG_BUILD: $(UbuntuSwigBuild)
+              UBUNTU_SWIG_VERSION: $(UbuntuSwigVersion)
+          - publish: 'build'
+
+      - job: static_binaries
+        variables:
+          CVC4Version: '1.8'
+          UbuntuMirror: 'http://azure.archive.ubuntu.com/ubuntu'
+          UbuntuSwigBuild: '5build1'
+          UbuntuSwigVersion: '4.0.1'
+        strategy:
+          matrix:
+            Linux:
+              VMImage: ubuntu-latest
+        pool:
+          vmImage: $(VMImage)
+        steps:
+          - task: Bash@3
+            inputs:
+              filePath: 'build-static.sh'
             env:
               BUILD_NAME: $(VMImage)
               CVC4_VERSION: $(CVC4Version)

--- a/build-static.sh
+++ b/build-static.sh
@@ -87,8 +87,8 @@ install-dependencies() {
 }
 
 install-cvc4() {
-  FLAGS=(--abc --cadical --cryptominisat --drat2er --lfsc --symfpu
-    --python3 "--name=build-${2}" "--prefix=${1}" "--language-bindings=java")
+  FLAGS=(--abc --cadical --cryptominisat --drat2er --lfsc --symfpu --static-binary
+    --python3 "--name=build-${2}" "--prefix=${1}")
   GPL_FLAGS=(--gpl --cln --glpk)
 
   pushd src


### PR DESCRIPTION
For the process wrapped solver, we need some static build binaries. Currently, we link them dynamically. This PR is going to change this.